### PR TITLE
fix: resolve npm peer dep conflict and add missing boto3 dependency

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Node Dependencies
-        run: cd frontend && npm install
+        run: cd frontend && npm install --legacy-peer-deps
 
       - name: Install Python Dependencies
         run: |
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: cd frontend && npm install
+      - run: cd frontend && npm install --legacy-peer-deps
       - run: cd frontend && npm run lint 2>/dev/null || echo "No lint script"
       - run: cd frontend && npm run type-check 2>/dev/null || echo "No type-check script"
       - run: pip install flake8 black mypy 2>/dev/null || true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
-    "@vitejs/plugin-react": "^4.2.0",
+    "@vitejs/plugin-react": "^4.7.0",
     "@vitest/ui": "^1.0.0",
     "@vitest/coverage-v8": "^1.0.0",
     "eslint": "^8.54.0",
@@ -33,7 +33,7 @@
     "jsdom": "^28.0.0",
     "terser": "^5.46.0",
     "typescript": "^5.2.2",
-    "vite": "^8.0.5",
+    "vite": "^7.0.0",
     "vitest": "^1.0.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ stripe>=9.0.0
 cryptography>=42.0.0
 python-multipart>=0.0.9
 email-validator>=2.0.0
+
+# AWS SDK
+boto3>=1.34.0
+botocore>=1.34.0


### PR DESCRIPTION
## Summary

This PR fixes two CI/CD failures:

### Fix 1: npm ERESOLVE peer dependency conflict
**Error:** `npm error ERESOLVE could not resolve @vitejs/plugin-react@4.7.0 / vite@8.0.2`

**Root cause:** `vite@^8.0.5` was pinned in package.json but `@vitejs/plugin-react@^4.2.0` only supports `vite@^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0` as a peer dep.

**Fix:**
- Downgrade `vite` from `^8.0.5` → `^7.0.0`
- Update `@vitejs/plugin-react` to `^4.7.0` (latest, supports vite@7)
- Add `--legacy-peer-deps` flag to `npm install` in CI/CD workflow as a safety net

### Fix 2: Missing boto3 module
**Error:** `ModuleNotFoundError: No module named 'boto3'` in Deploy Revenue Engine job

**Root cause:** `backend/secrets/aws_secrets.py` imports `boto3` but it wasn't in `requirements.txt`

**Fix:** Add `boto3>=1.34.0` and `botocore>=1.34.0` to `requirements.txt`

Closes CI failures in:
- CI/CD Pipeline workflow (Run Tests + Lint and Type Check jobs)
- Deploy Revenue Engine workflow (Test Revenue Module job)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build tooling versions (Vite and related plugins)
  * Added AWS SDK dependencies (boto3 and botocore)
  * Modified CI/CD workflow to use legacy peer dependency resolution during installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->